### PR TITLE
Add link to home page when not on home page

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -5,7 +5,11 @@
         <img src="https://www.gravatar.com/avatar/{{ .Site.Params.gravatarHash }}?s=200"
              alt="gravatar" title="{{ .Site.Author.name }}">
         {{ end }}
-        <h1>The Conscientious Programmer</h1>
+        {{ if .IsHome }}
+        <h1>{{ .Site.Title }}</h1>
+        {{ else }}
+        <h1><a href="/">{{ .Site.Title }}</a></h1>
+        {{ end }}
         {{ with .Site.Params.tagline }}<p class="lead">{{ . | markdownify }}</p>{{ end }}
     </div>
 


### PR DESCRIPTION
I noticed when I wanted to see a list of all articles (not limited to the 24 days of Hackage) that there was no link to the index page.  This turns the title in the sidebar into such a link (when not already on the home node).